### PR TITLE
Add github pages deploy for maintainer

### DIFF
--- a/deploy-maintainer.js
+++ b/deploy-maintainer.js
@@ -1,0 +1,6 @@
+const ghpages = require('gh-pages');
+
+ghpages.publish('build', {
+  branch: 'gh-pages',
+  repo : 'https://github.com/Team-Up-Dev/team-up-dev.github.io.git'
+}, (err) => (err) && console.log(err));

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "npm-check": "npm-check",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
+    "deploy:maintainer": "node deploy-maintainer.js",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
Jadi nanti opsi buat deploy ada dua, satu buat maintainer yang punya akses ke repo langsung sama buat ke repo masing masing buat dipreview.